### PR TITLE
Extra colon in "main" key in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "emojione",
   "version": "1.4.1",
-  "main:": [
+  "main": [
     "assets/css/emojione.css",
     "lib/js/emojione.js"
   ],


### PR DESCRIPTION
This was causing some downstream tools like wiredep to malfunction.

Its a shame there is nothing to detect this typo automatically....  :sweat:
